### PR TITLE
Rename the metrics plugin and fix the auth loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Breaking Change
 
 - The github-repo-metrics plugin has been renamed to metrics-github-repo to match other plugins and what was written in the readme
-- The metrics plugin now properly loads the Auth module and handles reading the local token
+- The Auth library now returns the token as a string instead of an array, which was not properly parsed by the plugins
+
+### Changed
+
+- The plugins now correctly load the Auth library for pulling the token automatically
 
 ## [3.0.0] - 2017-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,71 +1,100 @@
-#Change Log
+# Change Log
+
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Breaking Change
+
+- The github-repo-metrics plugin has been renamed to metrics-github-repo to match other plugins and what was written in the readme
+- The metrics plugin now properly loads the Auth module and handles reading the local token
+
 ## [3.0.0] - 2017-07-11
+
 ### Added
+
 - Testing for Ruby 2.4.1 (@thomasriley)
-### Breaking Changes
+
+  ### Breaking Changes
+
 - Bump sensu-plugin runtime dependency to 2.0 for Ruby 2.4.1 support (@thomasriley)
 
 ## [2.0.0] - 2016-04-26
+
 ### Removed
+
 - support for Rubies 1.0.3 and 2.0
 
 ### Added
+
 - support for Ruby 2.3.0
 
 ### Changed
+
 - Check github status inside json
 
 ## [1.1.0] - 2015-09-10
+
 ### Added
+
 - check-github-system-status for checking the status of github itself
 
 ## [1.0.0] - 2015-08-14
+
 ### Added
+
 - check-github-rate-limit.rb for checking the rate limit of a user
 
 ### Changed
+
 - updated documentation urls
 - general gem cleanup
-- changed the name of *github-repo-metrics* to *metrics-github-repo* to keep with convention
+- changed the name of _github-repo-metrics_ to _metrics-github-repo_ to keep with convention
 
 ### Fixed
+
 - set binstubs to only be created for Ruby binaries
 
 ## [0.0.5] - 2015-07-14
+
 ### Changed
+
 - updated sensu-plugin gem to 1.2.0
 
 ### Removed
+
 - Remove JSON gem dep that is not longer needed with Ruby 1.9+
 
 ## [0.0.4] - 2015-06-02
 
 ### Added
+
 - check-user-2fa.rb
-    - Check to alert upon org users that do not have 2FA enabled
+
+  - Check to alert upon org users that do not have 2FA enabled
 
 ### Fixed
+
 - added binstubs
 
 ### Changed
+
 - removed cruft from /lib
 
 ## [0.0.3] - 2015-04-02
+
 ## [0.0.2] - 2015-02-12
+
 ## 0.0.1 - 2015-02-11
 
-[unreleased]: https://github.com/sensu-plugins/sensu-plugins-github/compare/3.0.0...HEAD
-[3.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/2.0.0...3.0.0
-[2.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/1.1.0...2.0.0
-[1.1.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/1.0.0...1.1.0
-[1.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.5...1.0.0
-[0.0.5]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.4...0.0.5
-[0.0.4]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.3...0.0.4
-[0.0.3]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.1...0.0.2
+[0.0.3]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.2...0.0.3
+[0.0.4]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.3...0.0.4
+[0.0.5]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.4...0.0.5
+[1.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.5...1.0.0
+[1.1.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/1.0.0...1.1.0
+[2.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/1.1.0...2.0.0
+[3.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/2.0.0...3.0.0
+[unreleased]: https://github.com/sensu-plugins/sensu-plugins-github/compare/3.0.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,12 +89,12 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## 0.0.1 - 2015-02-11
 
-[0.0.2]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.1...0.0.2
-[0.0.3]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.2...0.0.3
-[0.0.4]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.3...0.0.4
-[0.0.5]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.4...0.0.5
-[1.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.5...1.0.0
-[1.1.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/1.0.0...1.1.0
-[2.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/1.1.0...2.0.0
-[3.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/2.0.0...3.0.0
 [unreleased]: https://github.com/sensu-plugins/sensu-plugins-github/compare/3.0.0...HEAD
+[3.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/2.0.0...3.0.0
+[2.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/1.1.0...2.0.0
+[1.1.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/1.0.0...1.1.0
+[1.0.0]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.5...1.0.0
+[0.0.5]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.4...0.0.5
+[0.0.4]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.3...0.0.4
+[0.0.3]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.2...0.0.3
+[0.0.2]: https://github.com/sensu-plugins/sensu-plugins-github/compare/0.0.1...0.0.2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Functionality
 
-**github-repo-metrics**
+**metrics-github-repo**
 
 Interacts with Github API to generate metrics about repo.
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,12 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+args = %i[spec make_bin_executable yard rubocop check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new

--- a/bin/check-github-rate-limit.rb
+++ b/bin/check-github-rate-limit.rb
@@ -34,7 +34,7 @@ require 'json'
 $LOAD_PATH.unshift([File.expand_path(File.dirname(__FILE__)), '..', 'lib'].join('/'))
 require 'sensu-plugins-github'
 
-class CheckUser2FA < Sensu::Plugin::Check::CLI
+class CheckRateLimit < Sensu::Plugin::Check::CLI
   option :api,
          short: '-a URL',
          long: '--api URL',

--- a/bin/check-github-rate-limit.rb
+++ b/bin/check-github-rate-limit.rb
@@ -38,12 +38,14 @@ class CheckUser2FA < Sensu::Plugin::Check::CLI
   option :api,
          short: '-a URL',
          long: '--api URL',
-         description: 'Github API URL'
+         description: 'Github API URL',
+         default: 'https://api.github.com'
 
   option :token,
          short: '-t TOKEN',
          long: '--token TOKEN',
-         description: 'Github OAuth Token'
+         description: 'Github OAuth Token',
+         default: SensuPluginsGithub::Auth.acquire_git_token
 
   option :org,
          short: '-o ORG',
@@ -78,16 +80,7 @@ class CheckUser2FA < Sensu::Plugin::Check::CLI
   end
 
   def run
-    # Set the token from the commandline or read it in from a file.  Preference
-    # is given towards the later and at some point it may be enforced.
-    token = config[:token] || SensuPluginsGithub::Auth.acquire_git_token
-
-    # This is the default url and will be fine for most people,
-    # github enterprise customers will have a url based upon the org name and
-    # will need to set it at the commandline.
-    api_url = config[:api] || 'https://api.github.com'
-
-    data = api_request('/rate_limit', api_url, token)
+    data = api_request('/rate_limit', @config[:api], @config[:token])
 
     rate_val = 5000 - data['resources']['core']['remaining'].to_i
     crit_val = config[:crit_threshold].to_i

--- a/bin/check-github-rate-limit.rb
+++ b/bin/check-github-rate-limit.rb
@@ -31,6 +31,9 @@ require 'sensu-plugin/check/cli'
 require 'rest-client'
 require 'json'
 
+$LOAD_PATH.unshift([File.expand_path(File.dirname(__FILE__)), '..', 'lib'].join('/'))
+require 'sensu-plugins-github'
+
 class CheckUser2FA < Sensu::Plugin::Check::CLI
   option :api,
          short: '-a URL',

--- a/bin/check-user-2fa.rb
+++ b/bin/check-user-2fa.rb
@@ -31,8 +31,8 @@ require 'sensu-plugin/check/cli'
 require 'rest-client'
 require 'json'
 
-# $LOAD_PATH.unshift([File.expand_path(File.dirname(__FILE__)), '..', 'lib'].join('/'))
-# require 'sensu-plugins-github'
+$LOAD_PATH.unshift([File.expand_path(File.dirname(__FILE__)), '..', 'lib'].join('/'))
+require 'sensu-plugins-github'
 
 class CheckUser2FA < Sensu::Plugin::Check::CLI
   option :api,

--- a/bin/check-user-2fa.rb
+++ b/bin/check-user-2fa.rb
@@ -38,12 +38,14 @@ class CheckUser2FA < Sensu::Plugin::Check::CLI
   option :api,
          short: '-a URL',
          long: '--api URL',
-         description: 'Github API URL'
+         description: 'Github API URL',
+         default: 'https://api.github.com'
 
   option :token,
          short: '-t TOKEN',
          long: '--token TOKEN',
-         description: 'Github OAuth Token'
+         description: 'Github OAuth Token',
+         default: SensuPluginsGithub::Auth.acquire_git_token
 
   option :org,
          short: '-o ORG',
@@ -80,21 +82,12 @@ class CheckUser2FA < Sensu::Plugin::Check::CLI
   end
 
   def run
-    # Set the token from the commandline or read it in from a file.  Preference
-    # is given towards the later and at some point it may be enforced.
-    token = config[:token] || SensuPluginsGithub::Auth.acquire_git_token
-
-    # This is the default url and will be fine for most people,
-    # github enterprise customers will have a url based upon the org name and
-    # will need to set it at the commandline.
-    api_url = config[:api] || 'https://api.github.com'
-
     # List to hold users who do not have 2FA
     user_list = []
 
     exclude_list = config[:exclude] || ''
 
-    data = api_request("/orgs/#{config[:org]}/members?filter=2fa_disabled", api_url, token)
+    data = api_request("/orgs/#{config[:org]}/members?filter=2fa_disabled", @config[:api], @config[:token])
     data.each do |d|
       user_list << d[:login] unless exclude_list.include?(d[:login])
     end

--- a/bin/metrics-github-repo.rb
+++ b/bin/metrics-github-repo.rb
@@ -31,7 +31,7 @@ require 'sensu-plugin/metric/cli'
 require 'rest-client'
 require 'json'
 
-$:.unshift([File.expand_path(File.dirname(__FILE__)), '..', 'lib'].join('/'))
+$LOAD_PATH.unshift([File.expand_path(File.dirname(__FILE__)), '..', 'lib'].join('/'))
 require 'sensu-plugins-github'
 
 #
@@ -124,7 +124,7 @@ class AggregateMetrics < Sensu::Plugin::Metric::CLI::Graphite
     [config[:repo] || acquire_org_repos].flatten.each do |repo|
       schema = "#{config[:scheme]}.#{config[:owner]}.#{repo}"
       now = Time.now.to_i
-      %w(pulls branches tags contributors languages).each do |resource|
+      %w[pulls branches tags contributors languages].each do |resource|
         output "#{schema}.stats.#{resource}", repo_api_request(repo, resource).count, now
       end
 

--- a/bin/metrics-github-repo.rb
+++ b/bin/metrics-github-repo.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 #
-#   github-repo-metrics
+#   metrics-github-repo
 #
 # DESCRIPTION:
 #   Interacts with Github API to generate metrics about repo.
@@ -31,8 +31,8 @@ require 'sensu-plugin/metric/cli'
 require 'rest-client'
 require 'json'
 
-# $:.unshift([File.expand_path(File.dirname(__FILE__)), '..', 'lib'].join('/'))
-# require 'sensu-plugins-github'
+$:.unshift([File.expand_path(File.dirname(__FILE__)), '..', 'lib'].join('/'))
+require 'sensu-plugins-github'
 
 #
 # AggregateMetrics
@@ -48,7 +48,7 @@ class AggregateMetrics < Sensu::Plugin::Metric::CLI::Graphite
          short: '-t TOKEN',
          long: '--token TOKEN',
          description: 'Github OAuth Token',
-         default: SensuPluginsGithub.acquire_git_token
+         default: SensuPluginsGithub::Auth.acquire_git_token
 
   option :repo,
          short: '-r REPO',

--- a/bin/metrics-github-repo.rb
+++ b/bin/metrics-github-repo.rb
@@ -17,6 +17,7 @@
 #
 # USAGE:
 #
+# metrics-github-repo.rb --owner myorg --repo myrepo
 #
 # NOTES:
 #

--- a/lib/sensu-plugins-github/auth.rb
+++ b/lib/sensu-plugins-github/auth.rb
@@ -4,9 +4,7 @@
 module SensuPluginsGithub
   module Auth
     def self.acquire_git_token
-      File.readlines(File.expand_path('~/.ssh/git_token')).each do |line|
-        @github_token = line
-      end
+      File.readlines(File.expand_path('~/.ssh/git_token'))[0]
     end
   end
 end

--- a/sensu-plugins-github.gemspec
+++ b/sensu-plugins-github.gemspec
@@ -7,7 +7,7 @@ require_relative 'lib/sensu-plugins-github'
 
 # pvt_key = '~/.ssh/gem-private_key.pem'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop: disable Metrics/BlockLength
   s.authors                = ['Sensu Plugins and contributors']
   # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
                               two-factor auth verification, and per-repo metrics'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-github'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => '@mattyjones',
@@ -41,9 +41,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
   s.add_development_dependency 'pry',                       '~> 0.10'
-  s.add_development_dependency 'rake',                      '~> 10.0'
+  s.add_development_dependency 'rake',                      '~> 12.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.49.0'
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
There's more to come here, but this fixes outright failures in the auth loading portion of the metrics plugin and fixes the name of that plugin to match that in the readme

Signed-off-by: Tim Smith <tsmith@chef.io>
